### PR TITLE
design : 팝업 닫기버튼, 팝업 배경 컴포넌트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import GlobalStyle from "./style/GlobalStyle";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { RecoilRoot } from "recoil";
 
 import Home from "./pages/home/Home";
 import NotFound from "./pages/NotFound/NotFound";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import SignUp from "./pages/sign/SignUp";
 import Subscribe from "./pages/subscribe/Subscribe";
 import MyCoupon from "./pages/myCoupon/MyCoupon";
 import HowToUse from "./pages/myCoupon/HowToUse";
+import UseCoupon from "./pages/myCoupon/UseCoupon";
 import Bardetail from "./pages/barDetail/Bardetail";
 import PasswordFind from "./pages/sign/PasswordFind";
 import PasswordReset from "./pages/sign/PasswordReset";
@@ -27,6 +28,7 @@ const App = () => {
         <Route path="/subscribe" element={<Subscribe />} />
         <Route path="/myCoupon" element={<MyCoupon />} />
         <Route path="/how-to-use" element={<HowToUse />} />
+        <Route path="/useCoupon" element={<UseCoupon />} />
         <Route path="/404" element={<NotFound />} />
         <Route path="/bar-detail" element={<Bardetail />} />
         <Route path="/password-find" element={<PasswordFind />} />

--- a/src/components/common/button/ButtonClose.tsx
+++ b/src/components/common/button/ButtonClose.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { styled } from "styled-components";
+
+import iconClose from "../../../assets/icon/icon_close.svg";
+import { ButtonCloseProps } from "../../../libs/interface/interfaceCommon";
+
+const ButtonClose = ({ top, right, onClose }: ButtonCloseProps) => {
+  return (
+    <ButtonContainer top={top} right={right} onClick={onClose}>
+      <img src={iconClose} alt="닫기 버튼" />
+    </ButtonContainer>
+  );
+};
+
+interface Position {
+  top: number;
+  right: number;
+}
+
+const iconSize = "15px";
+const iconPadding = "5px";
+const ButtonContainer = styled.button<Position>`
+  width: ${iconSize};
+  height: ${iconSize};
+  padding: ${iconPadding};
+  position: absolute;
+  top: ${(props) => `${props.top}px`};
+  right: ${(props) => `${props.right}px`};
+  cursor: pointer;
+`;
+
+export default ButtonClose;

--- a/src/components/common/darkBackground/DarkBackground.tsx
+++ b/src/components/common/darkBackground/DarkBackground.tsx
@@ -1,11 +1,7 @@
 import { styled } from "styled-components";
 
 import React, { useEffect } from "react";
-
-interface BackgroundType {
-  onClose: () => void;
-  children: React.ReactNode;
-}
+import { BackgroundType } from "../../../libs/interface/interfaceCommon";
 
 export const DarkBackground = ({ onClose, children }: BackgroundType) => {
   useEffect(() => {

--- a/src/components/common/darkBackground/DarkBackground.tsx
+++ b/src/components/common/darkBackground/DarkBackground.tsx
@@ -1,0 +1,34 @@
+import { styled } from "styled-components";
+
+import React, { useEffect } from "react";
+
+interface BackgroundType {
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const DarkBackground = ({ onClose, children }: BackgroundType) => {
+  useEffect(() => {
+    document.body.style.cssText = `
+      position: fixed; 
+      top: -${window.scrollY}px;
+      overflow-y: scroll;
+      width: 100%;`;
+    return () => {
+      const scrollY = document.body.style.top;
+      document.body.style.cssText = "";
+      window.scrollTo(0, parseInt(scrollY || "0", 10) * -1);
+    };
+  }, []);
+
+  return <BackgroundStyle onClick={onClose}>{children}</BackgroundStyle>;
+};
+
+export const BackgroundStyle = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+`;

--- a/src/components/common/text/index.ts
+++ b/src/components/common/text/index.ts
@@ -1,0 +1,1 @@
+export * from "./text";

--- a/src/components/common/text/text.tsx
+++ b/src/components/common/text/text.tsx
@@ -1,0 +1,63 @@
+import { styled } from "styled-components";
+import addressIcon from "../../assets/icon/icon_pin.svg";
+import timeIcon from "../../assets/icon/icon_clock.svg";
+import cocktailIcon from "../../assets/icon/icon_cocktail.png";
+import arrow from "../../assets/throughArrow.svg";
+
+export const grayTextWithIcon = styled.span`
+  display: block;
+  position: relative;
+  color: var(--gray500-color);
+  font-family: var(--font--Medium);
+  font-size: 12px;
+  padding: 5px 0 5px 20px;
+
+  &::before {
+    content: "";
+    width: 16px;
+    height: 16px;
+    position: absolute;
+    top: 3px;
+    left: 0;
+  }
+
+  & + span {
+    margin-top: 4px;
+  }
+`;
+
+export const Address = styled(grayTextWithIcon)`
+  &::before {
+    background: url(${addressIcon}) no-repeat center;
+  }
+`;
+
+export const Opening = styled(grayTextWithIcon)`
+  &::before {
+    background: url(${timeIcon}) no-repeat center / contain;
+  }
+`;
+
+export const CoverCharge = styled(grayTextWithIcon)`
+  & > span {
+    text-decoration: line-through;
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      width: 15px;
+      height: 12px;
+      top: 3px;
+      right: -13px;
+      background: url(${arrow}) no-repeat right;
+    }
+  }
+
+  &::before {
+    background: url(${cocktailIcon}) no-repeat center / contain;
+  }
+  strong {
+    margin-left: 18px;
+  }
+`;

--- a/src/components/common/text/text.tsx
+++ b/src/components/common/text/text.tsx
@@ -1,8 +1,8 @@
 import { styled } from "styled-components";
-import addressIcon from "../../assets/icon/icon_pin.svg";
-import timeIcon from "../../assets/icon/icon_clock.svg";
-import cocktailIcon from "../../assets/icon/icon_cocktail.png";
-import arrow from "../../assets/throughArrow.svg";
+import addressIcon from "../../../assets/icon/icon_pin.svg";
+import timeIcon from "../../../assets/icon/icon_clock.svg";
+import cocktailIcon from "../../../assets/icon/icon_cocktail.png";
+import arrow from "../../../assets/throughArrow.svg";
 
 export const grayTextWithIcon = styled.span`
   display: block;

--- a/src/libs/interface/interfaceCommon.tsx
+++ b/src/libs/interface/interfaceCommon.tsx
@@ -64,6 +64,6 @@ export interface ButtonCloseProps {
 }
 
 export interface BackgroundType {
-  onClose: (e: MOUSE_EVENT) => void;
+  onClose?: (e: MOUSE_EVENT) => void;
   children: React.ReactNode;
 }

--- a/src/libs/interface/interfaceCommon.tsx
+++ b/src/libs/interface/interfaceCommon.tsx
@@ -3,7 +3,7 @@
  */
 
 import { BUTTON_TYPE_VARIANTS, BUTTON_SIZE_VARIANTS, INPUT_TYPE_VARIANTS, INPUT_SIZE_VARIANTS, TAG_TYPE_VARIANTS, ITEM_TYPE_VARIANTS, MODAL_TYPE_VARIANTS } from "./typeCommon";
-import { BUTTON_EVENT, INPUT_EVENT } from "./typeEvent";
+import { BUTTON_EVENT, INPUT_EVENT, MOUSE_EVENT } from "./typeEvent";
 
 export interface AxiosOptions {
   timeout?: number;
@@ -55,4 +55,15 @@ export interface ModalProps {
   content: string;
   buttonoptions: ButtonProps[];
   activate: boolean;
+}
+
+export interface ButtonCloseProps {
+  top: number;
+  right: number;
+  onClose: (e: MOUSE_EVENT) => void;
+}
+
+export interface BackgroundType {
+  onClose: (e: MOUSE_EVENT) => void;
+  children: React.ReactNode;
 }

--- a/src/pages/barDetail/Bardetail.tsx
+++ b/src/pages/barDetail/Bardetail.tsx
@@ -4,16 +4,12 @@ import { styled } from "styled-components";
 
 import Layout from "../../layouts/Layout";
 
-import addressIcon from "../../assets/icon/icon_pin.svg";
-import timeIcon from "../../assets/icon/icon_clock.svg";
-import cocktailIcon from "../../assets/icon/icon_cocktail.png";
-import arrow from "../../assets/throughArrow.svg";
-
 import Cocktail from "../../components/bardetail/Cocktail";
 import ImgContainer from "../../components/bardetail/ImgContainer";
 
 import Button from "../../components/common/button/Button";
 import Tag from "../../components/tag/Tag";
+import { Address, Opening, CoverCharge } from "../../components/common/text";
 
 import { ButtonProps, TagProps } from "../../libs/interface/interfaceCommon";
 import { BarInfo } from "../../libs/utils/Bardetaildummy";
@@ -101,64 +97,6 @@ const BarInfoContainer = styled.section`
     font-family: var(--font--Medium);
     margin-bottom: 12px;
     line-height: 1.5;
-  }
-`;
-
-const grayText = styled.span`
-  display: block;
-  position: relative;
-  color: var(--gray500-color);
-  font-family: var(--font--Medium);
-  font-size: 12px;
-  padding: 5px 0 5px 20px;
-
-  &::before {
-    content: "";
-    width: 16px;
-    height: 16px;
-    position: absolute;
-    top: 3px;
-    left: 0;
-  }
-
-  & + span {
-    margin-top: 4px;
-  }
-`;
-
-const Address = styled(grayText)`
-  &::before {
-    background: url(${addressIcon}) no-repeat center;
-  }
-`;
-
-const Opening = styled(grayText)`
-  &::before {
-    background: url(${timeIcon}) no-repeat center / contain;
-  }
-`;
-
-const CoverCharge = styled(grayText)`
-  & > span {
-    text-decoration: line-through;
-    position: relative;
-
-    &::after {
-      content: "";
-      position: absolute;
-      width: 15px;
-      height: 12px;
-      top: 3px;
-      right: -13px;
-      background: url(${arrow}) no-repeat right;
-    }
-  }
-
-  &::before {
-    background: url(${cocktailIcon}) no-repeat center / contain;
-  }
-  strong {
-    margin-left: 18px;
   }
 `;
 

--- a/src/pages/myCoupon/UseCoupon.tsx
+++ b/src/pages/myCoupon/UseCoupon.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const UseCoupon = () => {
+  return <div>UseCoupon</div>;
+};
+
+export default UseCoupon;


### PR DESCRIPTION
### 🤚 잠깐!
- [x] PR 제목 형식 확인 [`feat: 기능 추가`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약
- [x] 기능 추가 : 팝업 배경 띄워질시, body 스크롤 break
- [x] 마크업 & 스타일 : 팝업 닫기버튼, 팝업 배경 컴포넌트
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- PR요약에 써있습니다

<br>

## 🌟 전달 사항

- 닫기 버튼
  - 사용하실때 다음 Props들 넘겨주시면 되고, 부모 요소에 position속성 필요해요
    - top : 버튼 top 위치 `number`
    - right : 버튼 right 위치 `number`
    - onClose : 닫기 이벤트 핸들러


- 팝업 배경 
  - onClose : 닫기 이벤트 핸들러 (optional)
  - children으로 띄울 팝업을 넘겨주셔야 합니다
  - 팝업 배경이 마운트되면 외부의 스크롤 작동이 중지됩니다
    - 참고 글 : https://joylee-developer.tistory.com/185

<br>

## ⚠️ Issue Number
- #62 

<br><br>
