### PR TITLE
fix : ScrollMain css 수정

### DIFF
--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -41,7 +41,11 @@ const FixHeader = styled.header`
 `;
 
 const ScrollMain = styled.div`
-  height: calc(100vh - 115px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  height: calc(100vh - 112px);
   overflow-y: auto;
 
   &::-webkit-scrollbar-track {


### PR DESCRIPTION
### 🤚 잠깐!
- [x] PR 제목 형식 확인 [`feat: 기능 추가`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약
- [ ] 기능 추가 :
- [x] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 바 디테일 페이지 바깥 스크롤 생기는 오류 수정
- 푸터 바닥에 붙어있게 수정

<br>

## 🌟 전달 사항

- ScrollMain 에 있는 height는 없으면 스크롤 동작이 아예 안되서 이거 외엔 높이는 준거 없어서 괜찮지 않을까 싶어용! 전체 넓이 100vh로 하고 헤더 값만 빼준 부분은 스크롤 생겨라 해둔거라...!

<br>

## ⚠️ Issue Number
- #6 

<br><br>
